### PR TITLE
feat: build event discovery and creation surfaces

### DIFF
--- a/apps/web/app/(admin)/layout.tsx
+++ b/apps/web/app/(admin)/layout.tsx
@@ -20,10 +20,10 @@ export default function AdminLayout({
       >
         <h2>Moderation</h2>
         <ul style={{ listStyle: 'none', padding: 0, marginTop: 24 }}>
-          <li style={{ marginBottom: 12 }}><a href="/admin/dashboard">Dashboard</a></li>
-          <li style={{ marginBottom: 12 }}><a href="/admin/dashboard?tab=leaders">Leaders</a></li>
-          <li style={{ marginBottom: 12 }}><a href="/admin/dashboard?tab=events">Events</a></li>
-          <li><a href="/admin/dashboard?tab=reports">Reports</a></li>
+          <li style={{ marginBottom: 12 }}><a href="/dashboard">Dashboard</a></li>
+          <li style={{ marginBottom: 12 }}><a href="/dashboard?tab=leaders">Leaders</a></li>
+          <li style={{ marginBottom: 12 }}><a href="/dashboard?tab=events">Events</a></li>
+          <li><a href="/dashboard?tab=reports">Reports</a></li>
         </ul>
       </aside>
       <div style={{ padding: '32px' }}>{children}</div>

--- a/apps/web/app/explore/community/[slug]/leaderboard/page.tsx
+++ b/apps/web/app/explore/community/[slug]/leaderboard/page.tsx
@@ -1,25 +1,68 @@
-import { leaders } from '@/lib/mock';
+import { leaders, categories } from '@/lib/mock';
 
 export default function LeaderboardPage() {
-  const sorted = [...leaders].sort((a,b)=>b.score-a.score);
+  const categoryMap = new Map(categories.map((category) => [category.id, category.label]));
+  const sorted = [...leaders].sort((a, b) => b.score - a.score);
+
   return (
-    <main>
-      <h1 style={{ marginTop:0 }}>Leaderboard</h1>
-      <ol style={{ paddingLeft:0, listStyle:'none', display:'grid', gap:10, maxWidth:720 }}>
-        {sorted.map((l, i) => (
-          <li key={l.id} style={{
-            display:'grid', gridTemplateColumns:'56px 1fr 120px', alignItems:'center',
-            gap:12, padding:'12px 14px', border:'1px solid rgba(148,163,184,0.25)', borderRadius:12,
-            background:'rgba(2,6,23,.35)'
-          }}>
-            <span style={{ fontSize:24, opacity:.8 }}>#{i+1}</span>
-            <div>
-              <div style={{ fontWeight:600 }}>{l.name}</div>
-              <div style={{ color:'#cbd5e1', fontSize:14 }}>{l.area}</div>
-            </div>
-            <div style={{ justifySelf:'end', fontWeight:700 }}>{l.score} pts</div>
-          </li>
-        ))}
+    <main style={{ display: 'grid', gap: 24 }}>
+      <header>
+        <h1 style={{ marginTop: 0 }}>Contributor leaderboard</h1>
+        <p style={{ color: 'var(--text-soft)', marginBottom: 0 }}>
+          Track who is earning the most pins across events. Scores update as
+          hosts create sessions, attract bookings, and collect five-star
+          reviews.
+        </p>
+      </header>
+      <ol
+        style={{
+          paddingLeft: 0,
+          listStyle: 'none',
+          display: 'grid',
+          gap: 12,
+          maxWidth: 880,
+        }}
+      >
+        {sorted.map((leader, index) => {
+          const price = `${leader.price.min.toFixed(0)}-${leader.price.max.toFixed(0)} USD`;
+          const categoryLabels = leader.categories
+            .map((id) => categoryMap.get(id))
+            .filter(Boolean)
+            .join(', ');
+
+          return (
+            <li
+              key={leader.id}
+              style={{
+                display: 'grid',
+                gap: 12,
+                padding: '16px 18px',
+                border: '1px solid rgba(148,163,184,0.25)',
+                borderRadius: 16,
+                background: 'rgba(2,6,23,0.35)',
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                  <span style={{ fontSize: 24, opacity: 0.8 }}>#{index + 1}</span>
+                  <div>
+                    <div style={{ fontWeight: 600 }}>{leader.name}</div>
+                    <div style={{ color: 'var(--text-soft)', fontSize: 14 }}>
+                      {leader.area}
+                    </div>
+                  </div>
+                </div>
+                <strong style={{ fontSize: 18 }}>{leader.score} pts</strong>
+              </div>
+              <div style={{ fontSize: 13, color: 'var(--text-soft)', display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+                <span>Badges: {leader.badges.join(' • ')}</span>
+                <span>Categories: {categoryLabels}</span>
+                <span>Rate: {price}</span>
+                <span>Rating: {leader.rating.toFixed(2)} ★</span>
+              </div>
+            </li>
+          );
+        })}
       </ol>
     </main>
   );

--- a/apps/web/app/explore/community/[slug]/page.tsx
+++ b/apps/web/app/explore/community/[slug]/page.tsx
@@ -1,33 +1,193 @@
 import { notFound } from 'next/navigation';
-import { communities, events } from '@/lib/mock';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import {
+  categories,
+  communities,
+  events,
+  leaders,
+  locations,
+  type Event,
+  type Leader,
+} from '@/lib/mock';
+
+const cardStyle: CSSProperties = {
+  border: '1px solid rgba(148,163,184,0.18)',
+  borderRadius: 20,
+  background: 'linear-gradient(180deg, rgba(15,23,42,0.82), rgba(2,6,23,0.6))',
+  padding: 20,
+  display: 'grid',
+  gap: 12,
+};
+
+const pillStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 999,
+  padding: '6px 12px',
+  fontSize: 13,
+  border: '1px solid rgba(148,163,184,0.26)',
+  color: 'rgba(226,232,240,0.82)',
+};
+
+const currencySymbols: Record<string, string> = { USD: '$' };
+
+function formatPrice(event: Event) {
+  const symbol = currencySymbols[event.price.currency] ?? '';
+  return `${symbol}${event.price.min.toFixed(0)} – ${symbol}${event.price.max.toFixed(0)}`;
+}
+
+function formatLeaderPrice(leader: Leader) {
+  const symbol = currencySymbols[leader.price.currency] ?? '';
+  return `${symbol}${leader.price.min.toFixed(0)} – ${symbol}${leader.price.max.toFixed(0)}`;
+}
 
 export default function CommunityPage({ params }: { params: { slug: string } }) {
-  const comm = communities.find(c => c.slug === params.slug);
-  if (!comm) return notFound();
+  const community = communities.find((entry) => entry.slug === params.slug);
+  if (!community) return notFound();
 
-  const upcoming = events.filter(e => e.communitySlug === comm.slug);
+  const location = locations.find((entry) => entry.id === community.primaryLocationId);
+  const categoryLabels = community.categoryIds
+    .map((id) => categories.find((category) => category.id === id)?.label)
+    .filter(Boolean)
+    .join(', ');
+
+  const communityEvents = events.filter((event) => event.communitySlug === community.slug);
+  const leaderMap = new Map(leaders.map((leader) => [leader.id, leader]));
+
+  const featuredContributors = leaders
+    .filter((leader) => {
+      const sharesCategory = leader.categories.some((id) =>
+        community.categoryIds.includes(id)
+      );
+      const coversLocation = leader.locations.includes(community.primaryLocationId);
+      return sharesCategory && coversLocation;
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 4);
 
   return (
-    <main style={{ display:'grid', gap:18 }}>
-      <h1 style={{ margin:0 }}>{comm.name}</h1>
-      <p style={{ color:'#cbd5e1' }}>{comm.blurb}</p>
-      <p style={{ opacity:.85 }}>{comm.city} • {comm.members} members</p>
+    <main style={{ display: 'grid', gap: 28, paddingBottom: 64 }}>
+      <header style={{ display: 'grid', gap: 12 }}>
+        <Link
+          href="/explore"
+          style={{ fontSize: 13, color: 'var(--text-soft)', width: 'fit-content' }}
+        >
+          ← Back to explore
+        </Link>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+          <h1 style={{ margin: 0 }}>{community.name}</h1>
+          <span style={{ ...pillStyle, borderColor: 'rgba(56,189,248,0.35)' }}>
+            {community.members} members
+          </span>
+        </div>
+        <p style={{ margin: 0, color: 'var(--text-soft)', maxWidth: 720 }}>
+          {community.blurb}
+        </p>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: 14 }}>
+          <span style={{ color: 'var(--text-soft)' }}>
+            {location?.label ?? `${community.city}, CA`}
+          </span>
+          <span style={{ color: 'var(--text-soft)' }}>Focus: {categoryLabels || 'Community experiments'}</span>
+        </div>
+      </header>
 
-      <h2 style={{ margin:'8px 0' }}>Upcoming</h2>
-      <div style={{ display:'grid', gap:16, gridTemplateColumns:'repeat(auto-fit,minmax(260px,1fr))' }}>
-        {upcoming.map(e => (
-          <article key={e.id} style={card}>
-            <h3 style={{ margin:'0 0 6px' }}>{e.title}</h3>
-            <p style={{ margin:0 }}>{e.when} • {e.where}</p>
-          </article>
-        ))}
-        {upcoming.length === 0 && <p>No events yet. Be the first to host!</p>}
-      </div>
+      <section style={{ display: 'grid', gap: 16 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
+          <h2 style={{ margin: 0, fontSize: 24 }}>Upcoming sessions</h2>
+          <span style={{ fontSize: 13, opacity: 0.75 }}>
+            {communityEvents.length} scheduled
+          </span>
+        </div>
+        <div style={{ display: 'grid', gap: 16 }}>
+          {communityEvents.map((event) => {
+            const hosts = event.hostIds
+              .map((id) => leaderMap.get(id)?.name)
+              .filter(Boolean)
+              .join(', ');
+            const eventLocation = locations.find((entry) => entry.id === event.locationId);
+
+            return (
+              <article key={event.id} style={cardStyle}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16 }}>
+                  <div style={{ display: 'grid', gap: 6 }}>
+                    <span style={{ fontSize: 13, opacity: 0.7 }}>
+                      {event.when} • {event.timeslot}
+                    </span>
+                    <h3 style={{ margin: 0 }}>{event.title}</h3>
+                    <p style={{ margin: 0, color: 'var(--text-soft)' }}>{event.summary}</p>
+                  </div>
+                  <span style={{ ...pillStyle, border: 'none', background: 'rgba(56,189,248,0.16)' }}>
+                    {categories.find((category) => category.id === event.categoryId)?.label ?? 'Community event'}
+                  </span>
+                </div>
+                <div style={{ fontSize: 14, color: 'var(--text-soft)', display: 'flex', flexWrap: 'wrap', gap: 16 }}>
+                  <span>{eventLocation?.label ?? 'Local venue'} • {event.venue}</span>
+                  <span>Format: {event.format}</span>
+                  <span>Level: {event.skillLevel}</span>
+                  <span>Price: {formatPrice(event)}</span>
+                </div>
+                <div style={{ fontSize: 13, color: 'var(--text-soft)', display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
+                  <span>
+                    {event.seats.booked}/{event.seats.total} spots booked
+                  </span>
+                  <span>Organizers: {hosts || 'To be announced'}</span>
+                </div>
+              </article>
+            );
+          })}
+          {communityEvents.length === 0 && (
+            <article style={cardStyle}>
+              <h3 style={{ margin: '0 0 8px' }}>Be the first to host</h3>
+              <p style={{ margin: 0, color: 'var(--text-soft)' }}>
+                This community is looking for its next event. Bring your idea and claim the top spot on the contributor board.
+              </p>
+            </article>
+          )}
+        </div>
+      </section>
+
+      <section style={{ display: 'grid', gap: 16 }}>
+        <h2 style={{ margin: 0, fontSize: 24 }}>Contributors in this lane</h2>
+        <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
+          {featuredContributors.map((leader) => (
+            <article
+              key={leader.id}
+              style={{
+                border: '1px solid rgba(148,163,184,0.18)',
+                borderRadius: 16,
+                padding: 16,
+                background: 'rgba(15,23,42,0.65)',
+                display: 'grid',
+                gap: 6,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <strong>{leader.name}</strong>
+                <span style={{ fontSize: 13, opacity: 0.75 }}>{leader.score} pts</span>
+              </div>
+              <span style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                {leader.badges.join(' • ')}
+              </span>
+              <span style={{ fontSize: 13 }}>
+                Rate: {formatLeaderPrice(leader)} • Rating {leader.rating.toFixed(2)} ★
+              </span>
+              <span style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                {leader.bio}
+              </span>
+            </article>
+          ))}
+          {featuredContributors.length === 0 && (
+            <article style={cardStyle}>
+              <h3 style={{ margin: '0 0 8px' }}>No contributors yet</h3>
+              <p style={{ margin: 0, color: 'var(--text-soft)' }}>
+                Invite instructors to stake their claim in this category and unlock exclusive badges.
+              </p>
+            </article>
+          )}
+        </div>
+      </section>
     </main>
   );
 }
-
-const card: React.CSSProperties = {
-  border:'1px solid rgba(148,163,184,0.2)', borderRadius:16, padding:16,
-  background:'linear-gradient(180deg,rgba(30,41,59,.6),rgba(2,6,23,.4))'
-};

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -1,51 +1,919 @@
+'use client';
+
+import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
 import Link from 'next/link';
-import { communities, events, leaders } from '@/lib/mock';
+import type {
+  Category,
+  Event,
+  Leader,
+  LocationOption,
+  PriceRange,
+} from '@/lib/mock';
+import {
+  categories,
+  communities,
+  events,
+  leaders,
+  locations,
+} from '@/lib/mock';
+
+const currencySymbols: Record<string, string> = { USD: '$' };
+
+const defaultCategoryId = categories[0]?.id ?? '';
+const defaultLocationId = locations[0]?.id ?? '';
+
+const cardStyle: CSSProperties = {
+  border: '1px solid rgba(148,163,184,0.18)',
+  borderRadius: 20,
+  background: 'linear-gradient(180deg, rgba(15,23,42,0.82), rgba(2,6,23,0.6))',
+  padding: 20,
+  display: 'grid',
+  gap: 12,
+};
+
+const pillStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 999,
+  padding: '6px 12px',
+  fontSize: 13,
+  border: '1px solid rgba(148,163,184,0.26)',
+  color: 'rgba(226,232,240,0.82)',
+};
+
+type EventFormState = {
+  title: string;
+  summary: string;
+  categoryId: string;
+  locationId: string;
+  date: string;
+  start: string;
+  duration: string;
+  priceMin: string;
+  priceMax: string;
+  venue: string;
+  format: Event['format'];
+  skillLevel: Event['skillLevel'];
+};
+
+type DraftPreview = {
+  title: string;
+  summary: string;
+  schedule: string;
+  duration?: string;
+  locationLabel: string;
+  priceLabel: string;
+  categoryLabel: string;
+  format: string;
+  skillLevel: string;
+};
+
+function formatPriceRange(price: PriceRange) {
+  const symbol = currencySymbols[price.currency] ?? '';
+  return `${symbol}${price.min.toFixed(0)} – ${symbol}${price.max.toFixed(0)}`;
+}
+
+function formatDraftPrice(minInput: string, maxInput: string, currency: string = 'USD') {
+  const symbol = currencySymbols[currency] ?? '';
+  const parsedMin = minInput.trim() === '' ? undefined : Number(minInput);
+  const parsedMax = maxInput.trim() === '' ? undefined : Number(maxInput);
+  const hasMin = typeof parsedMin === 'number' && Number.isFinite(parsedMin);
+  const hasMax = typeof parsedMax === 'number' && Number.isFinite(parsedMax);
+
+  if (hasMin && hasMax) {
+    return `${symbol}${parsedMin.toFixed(0)} – ${symbol}${parsedMax.toFixed(0)}`;
+  }
+  if (hasMin) {
+    return `From ${symbol}${parsedMin.toFixed(0)}`;
+  }
+  if (hasMax) {
+    return `Up to ${symbol}${parsedMax.toFixed(0)}`;
+  }
+  return 'Set your price';
+}
+
+function percentFilled(event: Event) {
+  if (event.seats.total === 0) return 0;
+  return Math.round((event.seats.booked / event.seats.total) * 100);
+}
 
 export default function ExplorePage() {
-  return (
-    <main style={{ display:'grid', gap:28 }}>
-      <h1 style={{ margin:0 }}>Explore</h1>
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [selectedLocation, setSelectedLocation] = useState<string>('all');
+  const [categorySearch, setCategorySearch] = useState('');
+  const [formMessage, setFormMessage] = useState<string>('');
+  const [draftPreview, setDraftPreview] = useState<DraftPreview | null>(null);
+  const [formState, setFormState] = useState<EventFormState>({
+    title: '',
+    summary: '',
+    categoryId: defaultCategoryId,
+    locationId: defaultLocationId,
+    date: '',
+    start: '',
+    duration: '90',
+    priceMin: '',
+    priceMax: '',
+    venue: '',
+    format: 'In person',
+    skillLevel: 'All levels',
+  });
 
-      <section>
-        <h2 style={{ margin:'0 0 10px' }}>Communities nearby</h2>
-        <div style={{ display:'grid', gap:16, gridTemplateColumns:'repeat(auto-fit,minmax(260px,1fr))' }}>
-          {communities.map(c => (
-            <article key={c.slug} style={card}>
-              <h3 style={{ margin:'0 0 6px' }}>{c.name}</h3>
-              <p style={{ margin:'0 0 10px', color:'#cbd5e1' }}>{c.blurb}</p>
-              <p style={{ margin:0, opacity:.8 }}>{c.city} • {c.members} members</p>
-              <div style={{ marginTop:12 }}>
-                <Link href={`/community/${c.slug}`} style={btnSmall}>View</Link>
-              </div>
-            </article>
-          ))}
+  const categoryMap = useMemo(
+    () => new Map<string, Category>(categories.map((cat) => [cat.id, cat])),
+    []
+  );
+  const locationMap = useMemo(
+    () => new Map<string, LocationOption>(locations.map((loc) => [loc.id, loc])),
+    []
+  );
+  const leaderMap = useMemo(
+    () => new Map<string, Leader>(leaders.map((leader) => [leader.id, leader])),
+    []
+  );
+  const communityMap = useMemo(
+    () => new Map(communities.map((community) => [community.slug, community])),
+    []
+  );
+
+  const normalizedSearch = categorySearch.trim().toLowerCase();
+
+  const visibleCategories = useMemo(() => {
+    if (!normalizedSearch) return categories;
+    return categories.filter((category) => {
+      const haystack = [
+        category.label,
+        category.tagline,
+        ...category.keywords,
+      ]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(normalizedSearch);
+    });
+  }, [normalizedSearch]);
+
+  const filteredEvents = useMemo(() => {
+    return events.filter((event) => {
+      const matchesCategory =
+        selectedCategory === 'all' || event.categoryId === selectedCategory;
+      const matchesLocation =
+        selectedLocation === 'all' || event.locationId === selectedLocation;
+      const matchesSearch =
+        !normalizedSearch ||
+        event.title.toLowerCase().includes(normalizedSearch) ||
+        event.summary.toLowerCase().includes(normalizedSearch) ||
+        (categoryMap.get(event.categoryId)?.label
+          .toLowerCase()
+          .includes(normalizedSearch) ?? false);
+      return matchesCategory && matchesLocation && matchesSearch;
+    });
+  }, [selectedCategory, selectedLocation, normalizedSearch, categoryMap]);
+
+  const filteredCommunities = useMemo(() => {
+    return communities.filter((community) => {
+      const matchesCategory =
+        selectedCategory === 'all' ||
+        community.categoryIds.includes(selectedCategory);
+      const matchesLocation =
+        selectedLocation === 'all' ||
+        community.primaryLocationId === selectedLocation;
+      return matchesCategory && matchesLocation;
+    });
+  }, [selectedCategory, selectedLocation]);
+
+  const contributorShortlist = useMemo(() => {
+    return leaders
+      .filter((leader) => {
+        const matchesLocation =
+          selectedLocation === 'all' || leader.locations.includes(selectedLocation);
+        const matchesCategory =
+          selectedCategory === 'all' || leader.categories.includes(selectedCategory);
+        const matchesSearch =
+          !normalizedSearch ||
+          leader.name.toLowerCase().includes(normalizedSearch) ||
+          leader.expertise.some((item) =>
+            item.toLowerCase().includes(normalizedSearch)
+          ) ||
+          leader.categories.some((id) =>
+            categoryMap.get(id)?.label.toLowerCase().includes(normalizedSearch) ?? false
+          );
+        return matchesLocation && matchesCategory && matchesSearch;
+      })
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 4);
+  }, [selectedCategory, selectedLocation, normalizedSearch, categoryMap]);
+
+  const activeLocationLabel =
+    selectedLocation === 'all'
+      ? 'Across the Bay Area'
+      : locationMap.get(selectedLocation)?.label ?? 'Unknown location';
+  const activeCategoryLabel =
+    selectedCategory === 'all'
+      ? 'Every format'
+      : categoryMap.get(selectedCategory)?.label ?? 'Events';
+
+  const handleCategorySelect = (categoryId: string | 'all') => {
+    setSelectedCategory(categoryId);
+    if (categoryId !== 'all') {
+      setFormState((prev) => ({ ...prev, categoryId }));
+    }
+  };
+
+  const handleLocationSelect = (value: string) => {
+    setSelectedLocation(value);
+    if (value !== 'all') {
+      setFormState((prev) => ({ ...prev, locationId: value }));
+    }
+  };
+
+  const handleFormFieldChange = (
+    field: keyof EventFormState
+  ) =>
+    (
+      event:
+        | ChangeEvent<HTMLInputElement>
+        | ChangeEvent<HTMLTextAreaElement>
+        | ChangeEvent<HTMLSelectElement>
+    ) => {
+      const value = event.target.value;
+      setFormState((prev) => ({ ...prev, [field]: value }));
+    };
+
+  const handleCreateEvent = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!formState.title || !formState.date || !formState.start) {
+      setFormMessage('Add a title and schedule to generate your draft preview.');
+      setDraftPreview(null);
+      return;
+    }
+
+    const locationLabel =
+      locationMap.get(formState.locationId)?.label ?? 'Location coming soon';
+    const categoryLabel =
+      categoryMap.get(formState.categoryId)?.label ?? 'Community event';
+
+    setDraftPreview({
+      title: formState.title,
+      summary:
+        formState.summary ||
+        'Bring your community together—add more details before publishing.',
+      schedule: `${formState.date} • ${formState.start} PT`,
+      duration: formState.duration
+        ? `${formState.duration} minute session`
+        : undefined,
+      locationLabel,
+      priceLabel: formatDraftPrice(formState.priceMin, formState.priceMax),
+      categoryLabel,
+      format: formState.format,
+      skillLevel: formState.skillLevel,
+    });
+    setFormMessage('Draft ready—share it with your crew for approval.');
+  };
+
+  return (
+    <main style={{ display: 'grid', gap: 32, paddingBottom: 80 }}>
+      <section
+        style={{
+          display: 'grid',
+          gap: 16,
+          padding: '24px 0 8px',
+        }}
+      >
+        <span style={{ fontSize: 13, letterSpacing: '0.08em', opacity: 0.72 }}>
+          PLAN & COMPETE
+        </span>
+        <h1 style={{ margin: 0, fontSize: 'clamp(32px, 5vw, 48px)' }}>
+          Build events, match with instructors, own your block.
+        </h1>
+        <p style={{ margin: 0, color: 'var(--text-soft)', maxWidth: 720 }}>
+          Spin up a new session, search top categories, and see the instructors
+          leading the charge in your neighborhood. Filters update the event feed,
+          community hubs, and contributor leaderboard in real time.
+        </p>
+      </section>
+
+      <section style={{ display: 'grid', gap: 16 }}>
+        <div style={{ display: 'grid', gap: 16 }}>
+          <label style={{ display: 'grid', gap: 8 }}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>Search categories</span>
+            <input
+              type="search"
+              value={categorySearch}
+              onChange={(event) => setCategorySearch(event.target.value)}
+              placeholder="Try “AI sessions”, “Boxing”, “Yoga sunrise”..."
+              style={{
+                padding: '14px 16px',
+                borderRadius: 12,
+                border: '1px solid rgba(148,163,184,0.32)',
+                background: 'rgba(15,23,42,0.65)',
+                color: 'inherit',
+              }}
+            />
+          </label>
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+            <button
+              type="button"
+              onClick={() => handleCategorySelect('all')}
+              style={{
+                ...pillStyle,
+                background:
+                  selectedCategory === 'all'
+                    ? 'rgba(56,189,248,0.16)'
+                    : 'transparent',
+                borderColor:
+                  selectedCategory === 'all'
+                    ? 'rgba(56,189,248,0.45)'
+                    : 'rgba(148,163,184,0.26)',
+                cursor: 'pointer',
+              }}
+            >
+              All categories
+            </button>
+            {visibleCategories.map((category) => {
+              const isActive = selectedCategory === category.id;
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  onClick={() => handleCategorySelect(category.id)}
+                  style={{
+                    ...pillStyle,
+                    background: isActive
+                      ? 'rgba(236,72,153,0.16)'
+                      : 'transparent',
+                    borderColor: isActive
+                      ? 'rgba(236,72,153,0.45)'
+                      : 'rgba(148,163,184,0.26)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {category.label}
+                </button>
+              );
+            })}
+            {visibleCategories.length === 0 && (
+              <span style={{ color: 'var(--text-soft)' }}>
+                No categories match “{categorySearch}” yet.
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: 16,
+            flexWrap: 'wrap',
+            alignItems: 'center',
+          }}
+        >
+          <label style={{ display: 'grid', gap: 8, minWidth: 240 }}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>Filter by location</span>
+            <select
+              value={selectedLocation}
+              onChange={(event) => handleLocationSelect(event.target.value)}
+              style={{
+                padding: '14px 16px',
+                borderRadius: 12,
+                border: '1px solid rgba(148,163,184,0.32)',
+                background: 'rgba(15,23,42,0.65)',
+                color: 'inherit',
+              }}
+            >
+              <option value="all">All locations</option>
+              {locations.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {location.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div style={{ fontSize: 14, color: 'var(--text-soft)' }}>
+            Viewing <strong style={{ color: 'var(--text-strong)' }}>{activeCategoryLabel}</strong>{' '}
+            in <strong style={{ color: 'var(--text-strong)' }}>{activeLocationLabel}</strong>
+          </div>
         </div>
       </section>
 
-      <section>
-        <h2 style={{ margin:'12px 0 10px' }}>This week</h2>
-        <div style={{ display:'grid', gap:16, gridTemplateColumns:'repeat(auto-fit,minmax(260px,1fr))' }}>
-          {events.map(e => {
-            const host = leaders.find(l => l.id === e.hostId)!;
+      <section
+        style={{
+          display: 'grid',
+          gap: 24,
+          gridTemplateColumns: 'minmax(0, 2.5fr) minmax(0, 1fr)',
+        }}
+      >
+        <div style={{ display: 'grid', gap: 20 }}>
+          <header style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <div>
+              <h2 style={{ margin: '0 0 4px', fontSize: 24 }}>Upcoming events</h2>
+              <p style={{ margin: 0, color: 'var(--text-soft)' }}>
+                Choose a session to reveal the organizers and pricing for that area.
+              </p>
+            </div>
+            <span style={{ alignSelf: 'flex-start', fontSize: 13, opacity: 0.7 }}>
+              {filteredEvents.length} events
+            </span>
+          </header>
+
+          <div
+            style={{
+              display: 'grid',
+              gap: 18,
+            }}
+          >
+            {filteredEvents.map((event) => {
+              const eventCategory = categoryMap.get(event.categoryId);
+              const eventLocation = locationMap.get(event.locationId);
+              const community = communityMap.get(event.communitySlug);
+              const hosts = event.hostIds
+                .map((id) => leaderMap.get(id)?.name)
+                .filter(Boolean)
+                .join(', ');
+              const fill = percentFilled(event);
+
+              return (
+                <article key={event.id} style={{ ...cardStyle, gap: 16 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'flex-start',
+                      gap: 16,
+                    }}
+                  >
+                    <div style={{ display: 'grid', gap: 6 }}>
+                      <span style={{ fontSize: 13, opacity: 0.7 }}>
+                        {event.when} • {event.timeslot}
+                      </span>
+                      <h3 style={{ margin: 0 }}>{event.title}</h3>
+                      <p style={{ margin: 0, color: 'var(--text-soft)' }}>{event.summary}</p>
+                    </div>
+                    <span style={{ ...pillStyle, border: 'none', background: 'rgba(56,189,248,0.16)' }}>
+                      {eventCategory?.label ?? 'Community event'}
+                    </span>
+                  </div>
+
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 16,
+                      fontSize: 14,
+                      color: 'var(--text-soft)',
+                    }}
+                  >
+                    <span>
+                      {eventLocation?.label ?? 'Location coming soon'} • {event.venue}
+                    </span>
+                    <span>Format: {event.format}</span>
+                    <span>Level: {event.skillLevel}</span>
+                    <span>Price: {formatPriceRange(event.price)}</span>
+                  </div>
+
+                  <div style={{ display: 'grid', gap: 8 }}>
+                    <div
+                      style={{
+                        height: 6,
+                        borderRadius: 999,
+                        background: 'rgba(148,163,184,0.22)',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: `${fill}%`,
+                          background: 'linear-gradient(90deg, #38bdf8, #f472b6)',
+                          height: '100%',
+                        }}
+                      />
+                    </div>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        fontSize: 13,
+                        color: 'var(--text-soft)',
+                      }}
+                    >
+                      <span>
+                        {event.seats.booked}/{event.seats.total} spots booked ({fill}% full)
+                      </span>
+                      <span>Organizers: {hosts || 'TBA'}</span>
+                    </div>
+                  </div>
+
+                  <footer
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      flexWrap: 'wrap',
+                      gap: 12,
+                    }}
+                  >
+                    <Link
+                      href={`/explore/community/${event.communitySlug}`}
+                      style={{ ...pillStyle, borderColor: 'rgba(148,163,184,0.4)' }}
+                    >
+                      Visit {community?.name ?? 'community hub'}
+                    </Link>
+                    <span style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                      Hosts compete for top contributor badges here.
+                    </span>
+                  </footer>
+                </article>
+              );
+            })}
+            {filteredEvents.length === 0 && (
+              <article style={cardStyle}>
+                <h3 style={{ margin: '0 0 8px' }}>No events match yet</h3>
+                <p style={{ margin: 0, color: 'var(--text-soft)' }}>
+                  Try broadening your filters or clear the search to see all
+                  categories and neighborhoods.
+                </p>
+              </article>
+            )}
+          </div>
+        </div>
+
+        <aside style={{ display: 'grid', gap: 24 }}>
+          <section style={{ ...cardStyle, gap: 16 }}>
+            <header style={{ display: 'grid', gap: 4 }}>
+              <span style={{ fontSize: 13, opacity: 0.75 }}>Top contributors</span>
+              <h2 style={{ margin: 0, fontSize: 20 }}>Leaders in {activeLocationLabel}</h2>
+              <p style={{ margin: 0, color: 'var(--text-soft)', fontSize: 14 }}>
+                Filtered by {activeCategoryLabel.toLowerCase()}. Compare price
+                ranges and pick the coach that matches your vibe.
+              </p>
+            </header>
+            <div style={{ display: 'grid', gap: 12 }}>
+              {contributorShortlist.map((leader) => (
+                <article
+                  key={leader.id}
+                  style={{
+                    border: '1px solid rgba(148,163,184,0.18)',
+                    borderRadius: 16,
+                    padding: 16,
+                    background: 'rgba(15,23,42,0.65)',
+                    display: 'grid',
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <strong>{leader.name}</strong>
+                    <span style={{ fontSize: 13, opacity: 0.75 }}>{leader.score} pts</span>
+                  </div>
+                  <span style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                    {leader.badges.join(' • ')}
+                  </span>
+                  <span style={{ fontSize: 13 }}>
+                    Rate: {formatPriceRange(leader.price)} • Rating {leader.rating.toFixed(2)} ★
+                  </span>
+                  <span style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                    {leader.expertise[0]}
+                  </span>
+                </article>
+              ))}
+              {contributorShortlist.length === 0 && (
+                <p style={{ color: 'var(--text-soft)', fontSize: 14 }}>
+                  No contributors in view yet—invite instructors to claim this
+                  lane.
+                </p>
+              )}
+            </div>
+          </section>
+
+          <section style={{ ...cardStyle, gap: 16 }}>
+            <header style={{ display: 'grid', gap: 4 }}>
+              <span style={{ fontSize: 13, opacity: 0.75 }}>Create an event</span>
+              <h2 style={{ margin: 0, fontSize: 20 }}>Draft your session</h2>
+              <p style={{ margin: 0, color: 'var(--text-soft)', fontSize: 14 }}>
+                Fill out the essentials and share the preview with your
+                co-hosts. Everything stays client-side.
+              </p>
+            </header>
+            <form
+              onSubmit={handleCreateEvent}
+              style={{ display: 'grid', gap: 12 }}
+            >
+              <label style={{ display: 'grid', gap: 6 }}>
+                <span>Title</span>
+                <input
+                  value={formState.title}
+                  onChange={handleFormFieldChange('title')}
+                  placeholder="Sunset mobility mashup"
+                  required
+                  style={{
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    border: '1px solid rgba(148,163,184,0.28)',
+                    background: 'rgba(15,23,42,0.65)',
+                    color: 'inherit',
+                  }}
+                />
+              </label>
+              <label style={{ display: 'grid', gap: 6 }}>
+                <span>Summary</span>
+                <textarea
+                  value={formState.summary}
+                  onChange={handleFormFieldChange('summary')}
+                  rows={3}
+                  placeholder="What makes this session hype?"
+                  style={{
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    border: '1px solid rgba(148,163,184,0.28)',
+                    background: 'rgba(15,23,42,0.65)',
+                    color: 'inherit',
+                    resize: 'vertical',
+                  }}
+                />
+              </label>
+              <label style={{ display: 'grid', gap: 6 }}>
+                <span>Category</span>
+                <select
+                  value={formState.categoryId}
+                  onChange={handleFormFieldChange('categoryId')}
+                  style={{
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    border: '1px solid rgba(148,163,184,0.28)',
+                    background: 'rgba(15,23,42,0.65)',
+                    color: 'inherit',
+                  }}
+                >
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={{ display: 'grid', gap: 6 }}>
+                <span>Location</span>
+                <select
+                  value={formState.locationId}
+                  onChange={handleFormFieldChange('locationId')}
+                  style={{
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    border: '1px solid rgba(148,163,184,0.28)',
+                    background: 'rgba(15,23,42,0.65)',
+                    color: 'inherit',
+                  }}
+                >
+                  {locations.map((location) => (
+                    <option key={location.id} value={location.id}>
+                      {location.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div style={{ display: 'grid', gap: 10, gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' }}>
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <span>Date</span>
+                  <input
+                    type="date"
+                    value={formState.date}
+                    onChange={handleFormFieldChange('date')}
+                    required
+                    style={{
+                      padding: '12px 14px',
+                      borderRadius: 10,
+                      border: '1px solid rgba(148,163,184,0.28)',
+                      background: 'rgba(15,23,42,0.65)',
+                      color: 'inherit',
+                    }}
+                  />
+                </label>
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <span>Start time</span>
+                  <input
+                    type="time"
+                    value={formState.start}
+                    onChange={handleFormFieldChange('start')}
+                    required
+                    style={{
+                      padding: '12px 14px',
+                      borderRadius: 10,
+                      border: '1px solid rgba(148,163,184,0.28)',
+                      background: 'rgba(15,23,42,0.65)',
+                      color: 'inherit',
+                    }}
+                  />
+                </label>
+              </div>
+              <label style={{ display: 'grid', gap: 6 }}>
+                <span>Duration (minutes)</span>
+                <input
+                  type="number"
+                  min={15}
+                  value={formState.duration}
+                  onChange={handleFormFieldChange('duration')}
+                  style={{
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    border: '1px solid rgba(148,163,184,0.28)',
+                    background: 'rgba(15,23,42,0.65)',
+                    color: 'inherit',
+                  }}
+                />
+              </label>
+              <div style={{ display: 'grid', gap: 10, gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' }}>
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <span>Min price (USD)</span>
+                  <input
+                    type="number"
+                    min={0}
+                    value={formState.priceMin}
+                    onChange={handleFormFieldChange('priceMin')}
+                    style={{
+                      padding: '12px 14px',
+                      borderRadius: 10,
+                      border: '1px solid rgba(148,163,184,0.28)',
+                      background: 'rgba(15,23,42,0.65)',
+                      color: 'inherit',
+                    }}
+                  />
+                </label>
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <span>Max price (USD)</span>
+                  <input
+                    type="number"
+                    min={0}
+                    value={formState.priceMax}
+                    onChange={handleFormFieldChange('priceMax')}
+                    style={{
+                      padding: '12px 14px',
+                      borderRadius: 10,
+                      border: '1px solid rgba(148,163,184,0.28)',
+                      background: 'rgba(15,23,42,0.65)',
+                      color: 'inherit',
+                    }}
+                  />
+                </label>
+              </div>
+              <label style={{ display: 'grid', gap: 6 }}>
+                <span>Venue</span>
+                <input
+                  value={formState.venue}
+                  onChange={handleFormFieldChange('venue')}
+                  placeholder="Neighborhood gym, studio, or park"
+                  style={{
+                    padding: '12px 14px',
+                    borderRadius: 10,
+                    border: '1px solid rgba(148,163,184,0.28)',
+                    background: 'rgba(15,23,42,0.65)',
+                    color: 'inherit',
+                  }}
+                />
+              </label>
+              <div style={{ display: 'grid', gap: 10, gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' }}>
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <span>Format</span>
+                  <select
+                    value={formState.format}
+                    onChange={handleFormFieldChange('format')}
+                    style={{
+                      padding: '12px 14px',
+                      borderRadius: 10,
+                      border: '1px solid rgba(148,163,184,0.28)',
+                      background: 'rgba(15,23,42,0.65)',
+                      color: 'inherit',
+                    }}
+                  >
+                    <option value="In person">In person</option>
+                    <option value="Hybrid">Hybrid</option>
+                    <option value="Virtual">Virtual</option>
+                  </select>
+                </label>
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <span>Skill level</span>
+                  <select
+                    value={formState.skillLevel}
+                    onChange={handleFormFieldChange('skillLevel')}
+                    style={{
+                      padding: '12px 14px',
+                      borderRadius: 10,
+                      border: '1px solid rgba(148,163,184,0.28)',
+                      background: 'rgba(15,23,42,0.65)',
+                      color: 'inherit',
+                    }}
+                  >
+                    <option value="All levels">All levels</option>
+                    <option value="Beginner">Beginner</option>
+                    <option value="Intermediate">Intermediate</option>
+                    <option value="Advanced">Advanced</option>
+                  </select>
+                </label>
+              </div>
+              <button
+                type="submit"
+                className="btn btn-primary"
+                style={{ width: '100%', marginTop: 4 }}
+              >
+                Generate draft preview
+              </button>
+            </form>
+            {formMessage && (
+              <p style={{ fontSize: 13, color: 'var(--text-soft)', margin: 0 }}>
+                {formMessage}
+              </p>
+            )}
+            {draftPreview && (
+              <article
+                style={{
+                  border: '1px dashed rgba(148,163,184,0.4)',
+                  borderRadius: 16,
+                  padding: 16,
+                  display: 'grid',
+                  gap: 8,
+                  background: 'rgba(15,23,42,0.4)',
+                }}
+              >
+                <span style={{ fontSize: 12, opacity: 0.7 }}>Draft preview</span>
+                <strong>{draftPreview.title}</strong>
+                <span style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                  {draftPreview.summary}
+                </span>
+                <span style={{ fontSize: 13 }}>
+                  {draftPreview.schedule}
+                  {draftPreview.duration ? ` • ${draftPreview.duration}` : ''}
+                </span>
+                <span style={{ fontSize: 13 }}>
+                  {draftPreview.locationLabel}
+                  {formState.venue ? ` • ${formState.venue}` : ''}
+                </span>
+                <span style={{ fontSize: 13 }}>
+                  {draftPreview.categoryLabel} • {draftPreview.format} •{' '}
+                  {draftPreview.skillLevel}
+                </span>
+                <span style={{ fontSize: 13 }}>Price: {draftPreview.priceLabel}</span>
+              </article>
+            )}
+          </section>
+        </aside>
+      </section>
+
+      <section style={{ display: 'grid', gap: 16 }}>
+        <header style={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
+          <div>
+            <h2 style={{ margin: '0 0 4px', fontSize: 24 }}>Communities to collaborate with</h2>
+            <p style={{ margin: 0, color: 'var(--text-soft)' }}>
+              Discover hubs where instructors are actively competing to host the
+              next big thing.
+            </p>
+          </div>
+          <span style={{ fontSize: 13, opacity: 0.7 }}>
+            {filteredCommunities.length} hubs
+          </span>
+        </header>
+        <div
+          style={{
+            display: 'grid',
+            gap: 18,
+            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          }}
+        >
+          {filteredCommunities.map((community) => {
+            const primaryLocation = locationMap.get(community.primaryLocationId);
+            const communityCategories = community.categoryIds
+              .map((id) => categoryMap.get(id)?.label)
+              .filter(Boolean)
+              .join(', ');
             return (
-              <article key={e.id} style={card}>
-                <h3 style={{ margin:'0 0 6px' }}>{e.title}</h3>
-                <p style={{ margin:0, opacity:.9 }}>{e.when} • {e.where}</p>
-                <p style={{ margin:'6px 0 0', color:'#cbd5e1' }}>Host: {host?.name}</p>
+              <article key={community.slug} style={cardStyle}>
+                <h3 style={{ margin: '0 0 4px' }}>{community.name}</h3>
+                <p style={{ margin: 0, color: 'var(--text-soft)' }}>{community.blurb}</p>
+                <div style={{ fontSize: 13, color: 'var(--text-soft)' }}>
+                  {primaryLocation?.label ?? community.city} • {community.members}{' '}
+                  members
+                </div>
+                <div style={{ fontSize: 13, opacity: 0.8 }}>
+                  Focus: {communityCategories || 'Community-led experiments'}
+                </div>
+                <Link
+                  href={`/explore/community/${community.slug}`}
+                  style={{ ...pillStyle, borderColor: 'rgba(148,163,184,0.4)' }}
+                >
+                  View community
+                </Link>
               </article>
             );
           })}
+          {filteredCommunities.length === 0 && (
+            <article style={cardStyle}>
+              <h3 style={{ margin: '0 0 8px' }}>No hubs match your filters</h3>
+              <p style={{ margin: 0, color: 'var(--text-soft)' }}>
+                Adjust category or location to surface active organizers nearby.
+              </p>
+            </article>
+          )}
         </div>
       </section>
     </main>
   );
 }
-
-const card: React.CSSProperties = {
-  border:'1px solid rgba(148,163,184,0.2)', borderRadius:16, padding:16,
-  background:'linear-gradient(180deg,rgba(30,41,59,.6),rgba(2,6,23,.4))'
-};
-const btnSmall: React.CSSProperties = {
-  display:'inline-block', padding:'8px 12px', borderRadius:10,
-  border:'1px solid rgba(148,163,184,0.3)'
-};

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,11 +1,15 @@
 import Link from 'next/link';
+import type { Route } from 'next';
+type NavLink =
+  | { label: string; href: Route; kind?: 'route' }
+  | { label: string; href: `#${string}`; kind: 'anchor' };
 
-const navLinks = [
-  { label: 'Home', href: '/' },
-  { label: 'Leaders', href: '#leaders' },
-  { label: 'Events', href: '#events' },
-  { label: 'Matchups', href: '#matchups' },
-  { label: 'Admin', href: '/admin/dashboard' },
+const navLinks: NavLink[] = [
+  { label: 'Home', href: '/', kind: 'route' },
+  { label: 'Leaders', href: '#leaders', kind: 'anchor' },
+  { label: 'Events', href: '#events', kind: 'anchor' },
+  { label: 'Matchups', href: '#matchups', kind: 'anchor' },
+  { label: 'Admin', href: '/dashboard', kind: 'route' },
 ];
 
 const featureHighlights = [
@@ -75,8 +79,8 @@ export default function HomePage() {
         <nav>
           <ul className="nav-links">
             {navLinks.map((link) => {
-              const isAnchor = link.href.startsWith('#');
-              const isActive = link.href === '/';
+              const isAnchor = link.kind === 'anchor';
+              const isActive = !isAnchor && link.href === '/';
               const linkClass = isActive ? 'nav-link-active' : undefined;
 
               return (
@@ -96,9 +100,9 @@ export default function HomePage() {
           </ul>
         </nav>
         <div className="header-actions">
-          <Link href="/login" className="btn btn-secondary">
+          <a href="/login" className="btn btn-secondary">
             Sign In
-          </Link>
+          </a>
           <a href="#waitlist" className="btn btn-primary">
             Join the Waitlist
           </a>
@@ -123,7 +127,7 @@ export default function HomePage() {
             <a href="#events" className="btn btn-secondary">
               See Event Highlights
             </a>
-            <Link href="/admin/dashboard" className="btn btn-secondary">
+            <Link href="/dashboard" className="btn btn-secondary">
               Launch Admin Console
             </Link>
           </div>
@@ -164,7 +168,7 @@ export default function HomePage() {
               <span>{feature.label}</span>
               <h3>{feature.title}</h3>
               <p>{feature.description}</p>
-              <Link href="/admin/dashboard" className="btn btn-secondary" style={{ width: 'fit-content' }}>
+              <Link href="/dashboard" className="btn btn-secondary" style={{ width: 'fit-content' }}>
                 Build a bracket
               </Link>
             </article>
@@ -207,7 +211,7 @@ export default function HomePage() {
               <span style={{ color: 'var(--accent-primary)', fontSize: 14, letterSpacing: '0.08em' }}>
                 {matchup.date}
               </span>
-              <Link href="/admin/dashboard" className="btn btn-secondary" style={{ width: 'fit-content' }}>
+              <Link href="/dashboard" className="btn btn-secondary" style={{ width: 'fit-content' }}>
                 Manage matchup
               </Link>
             </div>
@@ -225,7 +229,7 @@ export default function HomePage() {
           <a href="mailto:founders@pinkings.app" className="btn btn-primary">
             Request an invite
           </a>
-          <Link href="/admin/dashboard" className="btn btn-secondary">
+          <Link href="/dashboard" className="btn btn-secondary">
             Preview the console
           </Link>
         </div>
@@ -234,8 +238,8 @@ export default function HomePage() {
       <footer className="site-footer">
         <span>© {new Date().getFullYear()} PinKings. Built for community hype squads.</span>
         <div className="footer-links">
-          <Link href="/privacy">Privacy</Link>
-          <Link href="/terms">Terms</Link>
+          <a href="/privacy">Privacy</a>
+          <a href="/terms">Terms</a>
           <a href="mailto:team@pinkings.app">Contact</a>
         </div>
       </footer>

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,21 +1,356 @@
-export type Leader = { id: string; name: string; area: string; score: number; badges: string[] };
-export type Community = { slug: string; name: string; city: string; members: number; blurb: string };
-export type Event = { id: string; title: string; when: string; where: string; hostId: string; communitySlug: string };
+export type PriceRange = {
+  currency: 'USD';
+  min: number;
+  max: number;
+};
+
+export type Category = {
+  id: string;
+  label: string;
+  tagline: string;
+  keywords: string[];
+};
+
+export type LocationOption = {
+  id: string;
+  label: string;
+  city: string;
+  area: string;
+  neighborhoods: string[];
+};
+
+export type Leader = {
+  id: string;
+  name: string;
+  area: string;
+  score: number;
+  badges: string[];
+  expertise: string[];
+  categories: string[];
+  locations: string[];
+  price: PriceRange;
+  rating: number;
+  sessionsHosted: number;
+  bio: string;
+};
+
+export type Community = {
+  slug: string;
+  name: string;
+  city: string;
+  members: number;
+  blurb: string;
+  categoryIds: string[];
+  primaryLocationId: string;
+};
+
+export type Event = {
+  id: string;
+  title: string;
+  summary: string;
+  categoryId: string;
+  when: string;
+  timeslot: string;
+  locationId: string;
+  venue: string;
+  communitySlug: string;
+  hostIds: string[];
+  price: PriceRange;
+  seats: {
+    total: number;
+    booked: number;
+  };
+  format: 'In person' | 'Hybrid' | 'Virtual';
+  skillLevel: 'Beginner' | 'Intermediate' | 'Advanced' | 'All levels';
+};
+
+export const categories: Category[] = [
+  {
+    id: 'tech',
+    label: 'Tech Build Nights',
+    tagline: 'Prototype apps, automate workflows, and ship fast with local mentors.',
+    keywords: ['code', 'build', 'hackathon', 'startup'],
+  },
+  {
+    id: 'ai',
+    label: 'AI & Data Sessions',
+    tagline: 'Hands-on labs for machine learning, prompt craft, and applied AI.',
+    keywords: ['machine learning', 'prompt', 'llm', 'data'],
+  },
+  {
+    id: 'fitness',
+    label: 'Functional Fitness',
+    tagline: 'Strength circuits, conditioning ladders, and community gym meetups.',
+    keywords: ['gym', 'strength', 'conditioning', 'community'],
+  },
+  {
+    id: 'yoga',
+    label: 'Yoga & Mindfulness',
+    tagline: 'Breathwork, flow classes, and restorative sessions under the sun.',
+    keywords: ['yoga', 'mindfulness', 'breathwork', 'mobility'],
+  },
+  {
+    id: 'boxing',
+    label: 'Boxing & Combat Arts',
+    tagline: 'Technique clinics, pad work, and sparring strategy for all levels.',
+    keywords: ['boxing', 'sparring', 'combat', 'footwork'],
+  },
+];
+
+export const locations: LocationOption[] = [
+  {
+    id: 'south-bay',
+    label: 'South Bay • Sunnyvale, CA',
+    city: 'Sunnyvale',
+    area: 'South Bay',
+    neighborhoods: ['Downtown', 'Murphy Station', 'Heritage District'],
+  },
+  {
+    id: 'peninsula',
+    label: 'Peninsula • Mountain View, CA',
+    city: 'Mountain View',
+    area: 'Peninsula',
+    neighborhoods: ['Castro Street', 'Shoreline', 'North Bayshore'],
+  },
+  {
+    id: 'east-bay',
+    label: 'East Bay • Fremont, CA',
+    city: 'Fremont',
+    area: 'East Bay',
+    neighborhoods: ['Centerville', 'Warm Springs', 'Mission San Jose'],
+  },
+  {
+    id: 'san-francisco',
+    label: 'San Francisco, CA',
+    city: 'San Francisco',
+    area: 'City',
+    neighborhoods: ['SOMA', 'Mission', 'Sunset'],
+  },
+];
 
 export const leaders: Leader[] = [
-  { id:'l-1', name:'Asha Menon', area:'Sunnyvale Downtown', score: 912, badges:['Trailblazer','Host+','Helped 25'] },
-  { id:'l-2', name:'Marco Liu', area:'Santa Clara',        score: 860, badges:['Connector','Host','Helped 10'] },
-  { id:'l-3', name:'Riya Shah',  area:'Cupertino',         score: 788, badges:['Guide','Host','Safety Steward'] },
+  {
+    id: 'leader-asha',
+    name: 'Asha Menon',
+    area: 'Sunnyvale Downtown',
+    score: 912,
+    badges: ['Trailblazer', 'Host+', 'Helped 25'],
+    expertise: ['AI product strategy', 'No-code automation', 'Community prototyping'],
+    categories: ['tech', 'ai'],
+    locations: ['south-bay', 'peninsula'],
+    price: { currency: 'USD', min: 75, max: 120 },
+    rating: 4.9,
+    sessionsHosted: 42,
+    bio: 'Stanford design fellow turned AI coach helping teams go from ideas to working pilots in 48 hours.',
+  },
+  {
+    id: 'leader-marco',
+    name: 'Marco Liu',
+    area: 'Santa Clara',
+    score: 860,
+    badges: ['Connector', 'Host', 'Helped 10'],
+    expertise: ['Strength programming', 'Mobility coaching', 'Metcon design'],
+    categories: ['fitness', 'boxing'],
+    locations: ['south-bay', 'east-bay'],
+    price: { currency: 'USD', min: 45, max: 80 },
+    rating: 4.7,
+    sessionsHosted: 58,
+    bio: 'Former D1 strength coach bringing competition-style conditioning to neighborhood gyms.',
+  },
+  {
+    id: 'leader-riya',
+    name: 'Riya Shah',
+    area: 'Cupertino',
+    score: 788,
+    badges: ['Guide', 'Host', 'Safety Steward'],
+    expertise: ['Restorative flow', 'Mindfulness facilitation', 'Somatic release'],
+    categories: ['yoga'],
+    locations: ['peninsula', 'south-bay'],
+    price: { currency: 'USD', min: 35, max: 65 },
+    rating: 4.95,
+    sessionsHosted: 73,
+    bio: 'Trauma-informed yoga teacher blending flow, sound baths, and nervous system resets.',
+  },
+  {
+    id: 'leader-jordan',
+    name: 'Jordan Brooks',
+    area: 'San Jose',
+    score: 744,
+    badges: ['Corner Coach', 'Host', 'Pad Master'],
+    expertise: ['Footwork labs', 'Pad work', 'Fight camp planning'],
+    categories: ['boxing', 'fitness'],
+    locations: ['south-bay', 'east-bay'],
+    price: { currency: 'USD', min: 55, max: 95 },
+    rating: 4.8,
+    sessionsHosted: 39,
+    bio: 'Golden Gloves semifinalist mentoring new fighters on ring IQ and conditioning.',
+  },
+  {
+    id: 'leader-sofia',
+    name: 'Sofia Delgado',
+    area: 'San Francisco',
+    score: 702,
+    badges: ['Systems Thinker', 'Host', 'Community Ops'],
+    expertise: ['Data storytelling', 'Prompt design', 'Ops automation'],
+    categories: ['ai', 'tech'],
+    locations: ['san-francisco', 'peninsula'],
+    price: { currency: 'USD', min: 60, max: 105 },
+    rating: 4.85,
+    sessionsHosted: 51,
+    bio: 'Data scientist and facilitator translating AI concepts into friendly neighborhood labs.',
+  },
 ];
 
 export const communities: Community[] = [
-  { slug:'ai-builders', name:'AI Builders', city:'Sunnyvale', members: 842, blurb:'Weekend hands-on sessions—ship small, ship fast.' },
-  { slug:'football-sun', name:'Sunday Football', city:'Santa Clara', members: 430, blurb:'Casual 7-a-side every weekend.' },
-  { slug:'open-mics', name:'Open Mics', city:'Cupertino', members: 295, blurb:'Music, poetry, stories—no online clout required.' },
+  {
+    slug: 'ai-builders',
+    name: 'AI Builders Collective',
+    city: 'Sunnyvale',
+    members: 842,
+    blurb: 'Weekend hands-on sessions—ship small, ship fast with neighbors who love to tinker.',
+    categoryIds: ['tech', 'ai'],
+    primaryLocationId: 'south-bay',
+  },
+  {
+    slug: 'functional-fitness',
+    name: 'Functional Fitness Circuit',
+    city: 'Santa Clara',
+    members: 430,
+    blurb: 'Casual-but-competitive squads stacking strength, mobility, and stamina blocks.',
+    categoryIds: ['fitness', 'boxing'],
+    primaryLocationId: 'south-bay',
+  },
+  {
+    slug: 'sunrise-flow',
+    name: 'Sunrise Flow Collective',
+    city: 'Mountain View',
+    members: 295,
+    blurb: 'Music, movement, and mindful resets—no pretzel poses required.',
+    categoryIds: ['yoga'],
+    primaryLocationId: 'peninsula',
+  },
+  {
+    slug: 'downtown-boxing',
+    name: 'Downtown Boxing Crew',
+    city: 'San Jose',
+    members: 188,
+    blurb: 'Pad parties, sparring labs, and corner talks with fighters across the valley.',
+    categoryIds: ['boxing', 'fitness'],
+    primaryLocationId: 'south-bay',
+  },
 ];
 
 export const events: Event[] = [
-  { id:'e-101', title:'Hack a weekend MVP', when:'Sat 4pm', where:'Sunnyvale Library', hostId:'l-1', communitySlug:'ai-builders' },
-  { id:'e-102', title:'Pick-up football',   when:'Sun 8am', where:'Reed & Grant SC',   hostId:'l-2', communitySlug:'football-sun' },
-  { id:'e-103', title:'Acoustic night',     when:'Fri 7pm', where:'Main Street Park',  hostId:'l-3', communitySlug:'open-mics' },
+  {
+    id: 'event-ai-weekend',
+    title: 'AI Sprint Weekend',
+    summary: 'Prototype an MVP with community mentors and live feedback checkpoints.',
+    categoryId: 'ai',
+    when: 'Sat, Jun 22',
+    timeslot: '10:00 AM – 4:00 PM PT',
+    locationId: 'south-bay',
+    venue: 'Sunnyvale Maker Hub',
+    communitySlug: 'ai-builders',
+    hostIds: ['leader-asha', 'leader-sofia'],
+    price: { currency: 'USD', min: 79, max: 129 },
+    seats: { total: 36, booked: 28 },
+    format: 'Hybrid',
+    skillLevel: 'Intermediate',
+  },
+  {
+    id: 'event-ai-prototype-lab',
+    title: 'Rapid Prototyping Lab',
+    summary: 'Pair-build automations using community data sets and ready-to-use prompts.',
+    categoryId: 'tech',
+    when: 'Thu, Jun 27',
+    timeslot: '6:00 PM – 8:30 PM PT',
+    locationId: 'san-francisco',
+    venue: 'SoMa Foundry',
+    communitySlug: 'ai-builders',
+    hostIds: ['leader-sofia'],
+    price: { currency: 'USD', min: 65, max: 95 },
+    seats: { total: 24, booked: 19 },
+    format: 'In person',
+    skillLevel: 'All levels',
+  },
+  {
+    id: 'event-strength-gauntlet',
+    title: 'Strength Gauntlet Challenge',
+    summary: 'Team-based functional fitness ladder with real-time leaderboard tracking.',
+    categoryId: 'fitness',
+    when: 'Sun, Jun 23',
+    timeslot: '9:00 AM – 11:00 AM PT',
+    locationId: 'south-bay',
+    venue: 'Reed & Grant Sports Park',
+    communitySlug: 'functional-fitness',
+    hostIds: ['leader-marco'],
+    price: { currency: 'USD', min: 40, max: 70 },
+    seats: { total: 30, booked: 24 },
+    format: 'In person',
+    skillLevel: 'All levels',
+  },
+  {
+    id: 'event-sunrise-flow',
+    title: 'Sunrise Flow & Sound Bath',
+    summary: '60-minute flow ending with a sound bath and guided journaling on the lawn.',
+    categoryId: 'yoga',
+    when: 'Wed, Jun 26',
+    timeslot: '7:30 AM – 8:45 AM PT',
+    locationId: 'peninsula',
+    venue: 'Shoreline Park Meadow',
+    communitySlug: 'sunrise-flow',
+    hostIds: ['leader-riya'],
+    price: { currency: 'USD', min: 28, max: 48 },
+    seats: { total: 40, booked: 34 },
+    format: 'In person',
+    skillLevel: 'All levels',
+  },
+  {
+    id: 'event-evening-restorative',
+    title: 'Evening Restorative Reset',
+    summary: 'Gentle mobility, restorative poses, and breathwork for laptop-heavy weeks.',
+    categoryId: 'yoga',
+    when: 'Fri, Jun 28',
+    timeslot: '6:30 PM – 7:45 PM PT',
+    locationId: 'south-bay',
+    venue: 'Downtown Loft Studio',
+    communitySlug: 'sunrise-flow',
+    hostIds: ['leader-riya'],
+    price: { currency: 'USD', min: 32, max: 52 },
+    seats: { total: 26, booked: 18 },
+    format: 'Hybrid',
+    skillLevel: 'Beginner',
+  },
+  {
+    id: 'event-boxing-foundations',
+    title: 'Boxing Foundations Lab',
+    summary: 'Footwork, pad work, and timing drills with live sparring strategy breakdowns.',
+    categoryId: 'boxing',
+    when: 'Sat, Jun 29',
+    timeslot: '4:30 PM – 6:00 PM PT',
+    locationId: 'east-bay',
+    venue: 'Mission San Jose Boxing Gym',
+    communitySlug: 'downtown-boxing',
+    hostIds: ['leader-jordan'],
+    price: { currency: 'USD', min: 55, max: 90 },
+    seats: { total: 20, booked: 15 },
+    format: 'In person',
+    skillLevel: 'Beginner',
+  },
+  {
+    id: 'event-fight-night-prep',
+    title: 'Fight Night Prep Camp',
+    summary: 'Conditioning sprints, sparring rotations, and corner strategy reviews.',
+    categoryId: 'boxing',
+    when: 'Tue, Jul 2',
+    timeslot: '7:00 PM – 9:00 PM PT',
+    locationId: 'south-bay',
+    venue: 'San Jose Civic Training Hall',
+    communitySlug: 'downtown-boxing',
+    hostIds: ['leader-jordan', 'leader-marco'],
+    price: { currency: 'USD', min: 60, max: 110 },
+    seats: { total: 32, booked: 20 },
+    format: 'In person',
+    skillLevel: 'Intermediate',
+  },
 ];

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -9,10 +9,15 @@
       ],
       "@pin-kings/ui": [
         "../../packages/ui/src"
+      ],
+      "@/*": [
+        "./*"
       ]
     },
     "types": [
-      "node"
+      "node",
+      "react",
+      "react-dom"
     ],
     "module": "ESNext",
     "allowJs": true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,8 @@
     "react-native": "*"
   },
   "devDependencies": {
+    "@types/react": "^18.2.69",
+    "react": "18.2.0",
     "tsup": "^7.2.0",
     "typescript": "^5.4.5"
   }

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,12 +1,11 @@
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 export type PillProps = PropsWithChildren<{ color?: string }>;
 
 export function Pill({ children, color = '#2563eb' }: PillProps) {
-  return {
-    type: 'div',
-    props: {
-      style: {
+  return (
+    <div
+      style={{
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -16,8 +15,9 @@ export function Pill({ children, color = '#2563eb' }: PillProps) {
         padding: '4px 12px',
         fontSize: 12,
         fontWeight: 600,
-      },
-      children,
-    },
-  } as unknown as JSX.Element;
+      }}
+    >
+      {children}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- expand the shared mock data with categories, locations, enriched events, and contributor pricing to drive the new UI flows
- rebuild the explore experience with category/location filters, top contributor spotlighting, and a client-side event draft form, plus refreshed community and leaderboard detail views
- align navigation/admin routes, add the @/* alias, and update the UI package to compile with React while keeping Pill as a JSX component

## Testing
- pnpm --filter @pin-kings/web build

------
https://chatgpt.com/codex/tasks/task_e_68d2fd6ee774832ea89c0d3554c16355